### PR TITLE
Fix the tint on iOS

### DIFF
--- a/ios/RNGLModelViewManager.m
+++ b/ios/RNGLModelViewManager.m
@@ -58,9 +58,9 @@ RCT_CUSTOM_VIEW_PROPERTY(tint, NSDictionary, RNGLModelView)
 
   // If the alpha is not specified, we assume that the user wants a fully opaque object
   float alpha = [tint objectForKey:@"a"] == nil ? 1.0 : [[tint valueForKey:@"a"] floatValue];
-  float red = [[tint objectForKey:@"r"] == nil ? 1.0 : [tint valueForKey:@"r"] floatValue];
-  float green = [[tint objectForKey:@"g"] == nil ? 1.0 : [tint valueForKey:@"g"] floatValue];
-  float blue = [[tint objectForKey:@"b"] == nil ? 1.0 : [tint valueForKey:@"b"] floatValue];
+  float red = [tint objectForKey:@"r"] == nil ? 1.0 : [[tint valueForKey:@"r"] floatValue];
+  float green = [tint objectForKey:@"g"] == nil ? 1.0 : [[tint valueForKey:@"g"] floatValue];
+  float blue = [tint objectForKey:@"b"] == nil ? 1.0 : [[tint valueForKey:@"b"] floatValue];
 
   view.blendColor = [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gl-model-view",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "React Native bridge to GLView (iOS) and jPCT-AE (Android) - display and animate textured Wavefront .OBJ 3D models with 60fps",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Brackets were misaligned in RNGLModelViewManager.m file for ios, so it
wouldn't even compile. Thanks to @Dylan-at-LION for [spotting this issue](https://github.com/rastapasta/react-native-gl-model-view/issues/12#issuecomment-388432090).